### PR TITLE
Xml naming rules

### DIFF
--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -1,5 +1,14 @@
 import collections
+import re
 import six
+
+
+NameStartChar = re.compile(
+    u"(:|[A-Z]|_|[a-z]|[\xC0-\xD6]|[\xD8-\xF6]|[\xF8-\u02FF]|[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|[\U00010000-\U000EFFFF])",
+    re.UNICODE)
+NameChar = re.compile(
+    u"(\-|\.|[0-9]|\xB7|[\u0300-\u036F]|[\u203F-\u2040])",
+    re.UNICODE)
 
 ########################
 ###   NODE
@@ -26,8 +35,8 @@ class Node(object):
     entities = [('&', '&amp;'), ('<', '&lt;'), ('>', '&gt;')]
 
     def __init__(self, wrap="", tag="", data=None):
-        self.tag = tag
-        self.wrap = wrap
+        self.tag = self.sanitize_element(tag)
+        self.wrap = self.sanitize_element(wrap)
         self.data = data
         self.type = self.determine_type()
 
@@ -121,6 +130,27 @@ class Node(object):
                 val = "<%s>%s</%s>" % (self.tag, val, self.tag)
 
         return val, children
+
+    @staticmethod
+    def sanitize_element(wrap):
+        """
+            Convert `wrap` into a valid tag name applying the XML Naming Rules.
+
+                * Names can contain letters, numbers, and other characters
+                * Names cannot start with a number or punctuation character
+                * Names cannot start with the letters xml (or XML, or Xml, etc)
+                * Names cannot contain spaces
+                * Any name can be used, no words are reserved.
+
+            :ref: http://www.w3.org/TR/REC-xml/#NT-NameChar
+        """
+        if wrap and isinstance(wrap, six.string_types):
+            return ''.join(
+                ['_' if not NameStartChar.match(wrap) else ''] + \
+                ['_' if not (NameStartChar.match(c) or NameChar.match(c)) else c
+                 for c in wrap])
+        else:
+            return wrap
 
 ########################
 ###   CONVERTER

--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -145,6 +145,8 @@ class Node(object):
             :ref: http://www.w3.org/TR/REC-xml/#NT-NameChar
         """
         if wrap and isinstance(wrap, six.string_types):
+            if wrap.lower().startswith('xml'):
+                wrap = '_' + wrap
             return ''.join(
                 ['_' if not NameStartChar.match(wrap) else ''] + \
                 ['_' if not (NameStartChar.match(c) or NameChar.match(c)) else c

--- a/tests/build_test.py
+++ b/tests/build_test.py
@@ -10,6 +10,7 @@ import fudge
 describe "Build":
 
     def compare(self, data, result, **kwargs):
+        self.assertEqual.__self__.maxDiff = None
         converter = Converter(wrap='all', **kwargs)
         made = converter.build(data)
         self.assertEqual(result.strip(), made)

--- a/tests/examples/python_dict.py
+++ b/tests/examples/python_dict.py
@@ -95,4 +95,5 @@ data = {
     }
     , "lessthan" : "<"
     , "entitylist" : [{'ampersand':"&"}, {'mix':'>p<'}]
+    , "3badtagstart" : "x"
   }

--- a/tests/examples/python_dict.py
+++ b/tests/examples/python_dict.py
@@ -96,4 +96,6 @@ data = {
     , "lessthan" : "<"
     , "entitylist" : [{'ampersand':"&"}, {'mix':'>p<'}]
     , "3badtagstart" : "x"
+    , "xml_is_an_invalid_prefix" : "x"
+    , "Xml_with_other_case_is_an_invalid_prefix" : "x"
   }

--- a/tests/examples/xml_result.py
+++ b/tests/examples/xml_result.py
@@ -1,6 +1,7 @@
 result = \
 """<all>
   <_3badtagstart>x</_3badtagstart>
+  <_Xml_with_other_case_is_an_invalid_prefix>x</_Xml_with_other_case_is_an_invalid_prefix>
   <entitylist>
     <ampersand>&amp;</ampersand>
   </entitylist>
@@ -104,5 +105,6 @@ result = \
       <taglib-uri>cofax.tld</taglib-uri>
     </taglib>
   </web-app>
+  <_xml_is_an_invalid_prefix>x</_xml_is_an_invalid_prefix>
 </all>
 """

--- a/tests/examples/xml_result.py
+++ b/tests/examples/xml_result.py
@@ -1,5 +1,6 @@
 result = \
 """<all>
+  <_3badtagstart>x</_3badtagstart>
   <entitylist>
     <ampersand>&amp;</ampersand>
   </entitylist>


### PR DESCRIPTION
The values valid as python dictionary keys are not the same as the values valid as XML tags.

This patch validate the tag names using the W3C standard and replace the invalid characters with underscores (which are valid and recommended separation characters).

http://www.w3.org/TR/REC-xml/#NT-NameChar

**XML Naming Rules**
XML elements must follow these naming rules:

- Names can contain letters, numbers, and other characters
- Names cannot start with a number or punctuation character
- Names cannot start with the letters xml (or XML, or Xml, etc)
- Names cannot contain spaces
- Any name can be used, no words are reserved.

(Source: http://www.w3schools.com/xml/xml_elements.asp)