### PR TITLE
add support of Python38

### DIFF
--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -1,4 +1,5 @@
 import collections
+import collections.abc
 import re
 import six
 
@@ -102,9 +103,9 @@ class Node(object):
         data = self.data
         if isinstance(data, six.string_types) or isinstance(data, six.text_type):
             return 'flat'
-        elif isinstance(data, collections.Mapping):
+        elif isinstance(data, collections.abc.Mapping):
             return 'mapping'
-        elif isinstance(data, collections.Iterable):
+        elif isinstance(data, collections.abc.Iterable):
             return 'iterable'
         else:
             return 'flat'

--- a/tests/build_test.py
+++ b/tests/build_test.py
@@ -2,7 +2,6 @@
 
 from dict2xml import Converter, dict2xml
 
-from noseOfYeti.tokeniser.support import noy_sup_setUp
 from unittest import TestCase
 from textwrap import dedent
 import unittest

--- a/tests/converter_test.py
+++ b/tests/converter_test.py
@@ -2,7 +2,6 @@
 
 from dict2xml import Converter
 
-from noseOfYeti.tokeniser.support import noy_sup_setUp
 from fudge import patched_context
 from nose.tools import nottest
 from unittest import TestCase

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -2,11 +2,11 @@
 
 from dict2xml import Node, Converter
 
-from noseOfYeti.tokeniser.support import noy_sup_setUp
 from fudge import patched_context
 from nose.tools import nottest
 from unittest import TestCase
 import collections
+import collections.abc
 import unittest
 import fudge
 
@@ -49,7 +49,7 @@ describe TestCase, "Node":
                 )
 
         it "says anything that is a dict or subclass of collections.Mapping is a mapping":
-            class MappingObject(collections.Mapping):
+            class MappingObject(collections.abc.Mapping):
                 def __len__(self): return 0
                 def __iter__(self): return []
                 def __getitem__(self, key): return key


### PR DESCRIPTION
1. I've fixed collection.abc warning:
```
Python 3.7.4 (default, Oct 15 2019, 15:21:12) 
[GCC 7.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> collections.Mapping
__main__:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

2. I've remove unecessary import:
```from noseOfYeti.tokeniser.support import noy_sup_setUp```
https://github.com/delfick/nose-of-yeti/commit/7936b4070da973c5690b53813e20b30cdbf0c3be