### PR TITLE
packaging: include tests for distributors

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,6 @@
 include README.rst
 include LICENSE
+include test.sh
+include pytest.ini
+recursive-include tests *
+global-exclude *.pyc


### PR DESCRIPTION
fixes #19

The included files are not installed by pip into site-packages because the setup.py only includes the "dict2xml" package. And the tests themselves do not impose a large size to the resulting tarball