### PR TITLE
Ability to customize key sorting for mappings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,14 +68,33 @@ methods
     * indent: Amount to prefix each line for each level of nesting
     * newlines: Whether or not to use newlines
 
-``dict2xml.Converter.build(data, iterables_repeat_wrap=True, closed_tags_for=None)``
+``dict2xml.Converter.build(data, iterables_repeat_wrap=True, closed_tags_for=None, data_sorter=None)``
     Instance method on Converter that takes in the data and creates the xml string
 
     * iterables_repeat_wrap - when false the key the array is in will be repeated
     * closed_tags_for - an array of values that will produce self closing tags
+    * data_sorter - an object as explained below for sorting keys in maps
 
-    Note that to ensure the build is deterministic, keys in a mapping will be
-    sorted unless that mapping is an instance of ``collections.OrderedDict``.
+``dict2xml.DataSorter``
+    An object used to determine the sorting of keys for a map of data.
+
+    By default an ``OrderedDict`` object will not have it's keys sorted, but any
+    other type of mapping will.
+
+    It can be made so even ``OrderedDict`` will get sorted by passing in
+    ``data_sorter=DataSorter.always()``.
+
+    Or it can be made so that keys are produced from the sorting determined by
+    the mapping with ``data_sorter=DataSorter.never()``.
+
+    .. note:: When this library was first created python did not have deterministic
+       sorting for normal dictionaries which is why default everything gets sorted but
+       ``OrderedDict`` do not.
+
+    To create custom sorting logic requires an object that has a single ``keys_from``
+    method on it that accepts a map of data and returns a list of strings, where only
+    the keys that appear in the list will go into the output and those keys must exist
+    in the original mapping.
 
 Self closing tags
 -----------------

--- a/dict2xml/__init__.py
+++ b/dict2xml/__init__.py
@@ -1,4 +1,4 @@
-from dict2xml.logic import Converter, Node
+from dict2xml.logic import Converter, DataSorter, Node
 
 from .version import VERSION
 
@@ -8,4 +8,4 @@ def dict2xml(data, *args, **kwargs):
     return Converter(*args, **kwargs).build(data)
 
 
-__all__ = ["dict2xml", "Converter", "Node", "VERSION"]
+__all__ = ["dict2xml", "Converter", "Node", "VERSION", "DataSorter"]

--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -27,6 +27,18 @@ NameChar = re.compile(r"(\-|\.|[0-9]|\xB7|[\u0300-\u036F]|[\u203F-\u2040])")
 ########################
 
 
+class DataSorter:
+    """
+    Used to sort a map of data depending on it's type
+    """
+
+    def keys_from(self, data):
+        sorted_data = data
+        if not isinstance(data, collections.OrderedDict):
+            sorted_data = sorted(data)
+        return sorted_data
+
+
 class Node(object):
     """
     Represents each tag in the tree
@@ -54,6 +66,7 @@ class Node(object):
         self.wrap = self.sanitize_element(wrap)
         self.data = data
         self.type = self.determine_type()
+        self.data_sorter = DataSorter()
         self.closed_tags_for = closed_tags_for
         self.iterables_repeat_wrap = iterables_repeat_wrap
 
@@ -142,11 +155,9 @@ class Node(object):
         children = []
 
         if typ == "mapping":
-            sorted_data = data
-            if not isinstance(data, collections.OrderedDict):
-                sorted_data = sorted(data)
+            sorted_keys = self.data_sorter.keys_from(data)
 
-            for key in sorted_data:
+            for key in sorted_keys:
                 item = data[key]
                 children.append(
                     Node(

--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -60,13 +60,19 @@ class Node(object):
     entities = [("&", "&amp;"), ("<", "&lt;"), (">", "&gt;")]
 
     def __init__(
-        self, wrap="", tag="", data=None, iterables_repeat_wrap=True, closed_tags_for=None
+        self,
+        wrap="",
+        tag="",
+        data=None,
+        iterables_repeat_wrap=True,
+        closed_tags_for=None,
+        data_sorter=None,
     ):
         self.tag = self.sanitize_element(tag)
         self.wrap = self.sanitize_element(wrap)
         self.data = data
         self.type = self.determine_type()
-        self.data_sorter = DataSorter()
+        self.data_sorter = data_sorter if data_sorter is not None else DataSorter()
         self.closed_tags_for = closed_tags_for
         self.iterables_repeat_wrap = iterables_repeat_wrap
 
@@ -166,6 +172,7 @@ class Node(object):
                         item,
                         iterables_repeat_wrap=self.iterables_repeat_wrap,
                         closed_tags_for=self.closed_tags_for,
+                        data_sorter=self.data_sorter,
                     )
                 )
 
@@ -178,6 +185,7 @@ class Node(object):
                         item,
                         iterables_repeat_wrap=self.iterables_repeat_wrap,
                         closed_tags_for=self.closed_tags_for,
+                        data_sorter=self.data_sorter,
                     )
                 )
 
@@ -268,7 +276,7 @@ class Converter(object):
 
         return ret
 
-    def build(self, data, iterables_repeat_wrap=True, closed_tags_for=None):
+    def build(self, data, iterables_repeat_wrap=True, closed_tags_for=None, data_sorter=None):
         """Create a Node tree from the data and return it as a serialized xml string"""
         indenter = self._make_indenter()
         return Node(
@@ -276,4 +284,5 @@ class Converter(object):
             data=data,
             iterables_repeat_wrap=iterables_repeat_wrap,
             closed_tags_for=closed_tags_for,
+            data_sorter=data_sorter,
         ).serialize(indenter)

--- a/dict2xml/logic.py
+++ b/dict2xml/logic.py
@@ -38,6 +38,14 @@ class DataSorter:
             sorted_data = sorted(data)
         return sorted_data
 
+    class always:
+        def keys_from(self, data):
+            return sorted(data)
+
+    class never:
+        def keys_from(self, data):
+            return data
+
 
 class Node(object):
     """

--- a/tests/converter_test.py
+++ b/tests/converter_test.py
@@ -34,7 +34,11 @@ describe "Converter":
                 assert converter.build(data) is serialized
 
             FakeNode.assert_called_once_with(
-                wrap=wrap, data=data, iterables_repeat_wrap=True, closed_tags_for=None
+                wrap=wrap,
+                data=data,
+                iterables_repeat_wrap=True,
+                closed_tags_for=None,
+                data_sorter=None,
             )
             node.serialize.assert_called_once_with(indenter)
 

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -133,6 +133,72 @@ describe "Node":
                 ),
             ]
 
+        it "can be told to also sort OrderedDict":
+            called = []
+
+            nodes = [mock.Mock(name="n{0}".format(i)) for i in range(3)]
+
+            def N(*args, **kwargs):
+                called.append(1)
+                return nodes[len(called) - 1]
+
+            ds = DataSorter.always()
+            irw = mock.Mock("irw")
+            ctf = mock.Mock("ctf")
+            FakeNode = mock.Mock(name="Node", side_effect=N)
+
+            with mock.patch("dict2xml.logic.Node", FakeNode):
+                data = collections.OrderedDict([("b", 2), ("c", 3), ("a", 1)])
+                result = Node(
+                    data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ).convert()
+                assert result == ("", nodes)
+
+            assert FakeNode.mock_calls == [
+                mock.call(
+                    "a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+            ]
+
+        it "can be told to never sort":
+            called = []
+
+            nodes = [mock.Mock(name="n{0}".format(i)) for i in range(3)]
+
+            def N(*args, **kwargs):
+                called.append(1)
+                return nodes[len(called) - 1]
+
+            ds = DataSorter.never()
+            irw = mock.Mock("irw")
+            ctf = mock.Mock("ctf")
+            FakeNode = mock.Mock(name="Node", side_effect=N)
+
+            with mock.patch("dict2xml.logic.Node", FakeNode):
+                data = {"c": 3, "a": 1, "b": 2}
+                result = Node(
+                    data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ).convert()
+                assert result == ("", nodes)
+
+            assert FakeNode.mock_calls == [
+                mock.call(
+                    "c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+            ]
+
         it "returns list of Nodes with wrap as tag and item as data if type is iterable":
             called = []
 

--- a/tests/node_test.py
+++ b/tests/node_test.py
@@ -4,7 +4,7 @@ import collections
 import collections.abc
 from unittest import mock
 
-from dict2xml import Node
+from dict2xml import DataSorter, Node
 
 describe "Node":
     it "determines type at instantiation":
@@ -76,19 +76,28 @@ describe "Node":
                 called.append(1)
                 return nodes[len(called) - 1]
 
+            ds = DataSorter()
             irw = mock.Mock("irw")
             ctf = mock.Mock("ctf")
             FakeNode = mock.Mock(name="Node", side_effect=N)
 
             with mock.patch("dict2xml.logic.Node", FakeNode):
                 data = dict(a=1, b=2, c=3)
-                result = Node(data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf).convert()
+                result = Node(
+                    data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ).convert()
                 assert result == ("", nodes)
 
             assert FakeNode.mock_calls == [
-                mock.call("a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf),
+                mock.call(
+                    "a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
             ]
 
         it "respects the order of an OrderedDict":
@@ -100,19 +109,28 @@ describe "Node":
                 called.append(1)
                 return nodes[len(called) - 1]
 
+            ds = DataSorter()
             irw = mock.Mock("irw")
             ctf = mock.Mock("ctf")
             FakeNode = mock.Mock(name="Node", side_effect=N)
 
             with mock.patch("dict2xml.logic.Node", FakeNode):
                 data = collections.OrderedDict([("b", 2), ("c", 3), ("a", 1)])
-                result = Node(data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf).convert()
+                result = Node(
+                    data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ).convert()
                 assert result == ("", nodes)
 
             assert FakeNode.mock_calls == [
-                mock.call("b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf),
+                mock.call(
+                    "b", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "c", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "a", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
             ]
 
         it "returns list of Nodes with wrap as tag and item as data if type is iterable":
@@ -124,19 +142,28 @@ describe "Node":
                 called.append(1)
                 return nodes[len(called) - 1]
 
+            ds = DataSorter()
             irw = mock.Mock("irw")
             ctf = mock.Mock("ctf")
             FakeNode = mock.Mock(name="Node", side_effect=N)
 
             with mock.patch("dict2xml.logic.Node", FakeNode):
                 data = [1, 2, 3]
-                result = Node(data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf).convert()
+                result = Node(
+                    data=data, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ).convert()
                 assert result == ("", nodes)
 
             assert FakeNode.mock_calls == [
-                mock.call("", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf),
-                mock.call("", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf),
+                mock.call(
+                    "", "", 1, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "", "", 2, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
+                mock.call(
+                    "", "", 3, iterables_repeat_wrap=irw, closed_tags_for=ctf, data_sorter=ds
+                ),
             ]
 
         it "returns data enclosed in tags made from self.tag if not iterable or mapping":


### PR DESCRIPTION
It was pointed out in https://github.com/delfick/python-dict2xml/issues/24 that after Python3.6 the order of python dictionaries are deterministic, and that it would be useful to change the logic used to make a deterministic order.

To maintain the same behaviour I decided to go for an api where you pass in what you want, rather than retrospectively make the behaviour change automatically based on python version.

So here to decide if you always want alphabetic sorting you say

```
dict2xml.dict2xml(data, data_sorter=dict2xml.DataSorter.always())
```

Or if you like the order given to your data already and don't want it to sort

```
dict2xml.dict2xml(data, data_sorter=dict2xml.DataSorter.never())
```

With anything more complex easily provided with an object that implements a `keys_from` method that takes a mapping and returns a sorted list of the keys to be put into the result


@Finndersen