### PR TITLE
Ensure the arguments to the entrypoint are used correctly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,10 @@ Limitations
 Changelog
 ---------
 
+1.7.6 - TBD
+    * Fixed the ``dict2xml.dict2xml`` entry point to distribute options
+      correctly
+
 1.7.5 - 13 February 2024
     * Introduced the ``data_sorter`` option
 

--- a/dict2xml/__init__.py
+++ b/dict2xml/__init__.py
@@ -3,9 +3,22 @@ from dict2xml.logic import Converter, DataSorter, Node
 from .version import VERSION
 
 
-def dict2xml(data, *args, **kwargs):
+def dict2xml(
+    data,
+    wrap=None,
+    indent="  ",
+    newlines=True,
+    iterables_repeat_wrap=True,
+    closed_tags_for=None,
+    data_sorter=None,
+):
     """Return an XML string of a Python dict object."""
-    return Converter(*args, **kwargs).build(data)
+    return Converter(wrap=wrap, indent=indent, newlines=newlines).build(
+        data,
+        iterables_repeat_wrap=iterables_repeat_wrap,
+        closed_tags_for=closed_tags_for,
+        data_sorter=data_sorter,
+    )
 
 
 __all__ = ["dict2xml", "Converter", "Node", "VERSION", "DataSorter"]

--- a/tests/build_test.py
+++ b/tests/build_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from dict2xml import Converter, dict2xml
+from dict2xml import Converter, DataSorter, dict2xml
 
 examples = os.path.join(os.path.dirname(__file__), "examples")
 
@@ -22,12 +22,26 @@ describe "Build":
             converter.build.return_value = serialized
 
             FakeConverter = mock.Mock(name="Converter", return_value=converter)
+            data_sorter = DataSorter.never()
 
             with mock.patch("dict2xml.Converter", FakeConverter):
-                assert dict2xml(data, 1, 2, 3, a=5, b=8) is serialized
+                assert (
+                    dict2xml(
+                        data,
+                        wrap="wrap",
+                        indent="indent",
+                        newlines=False,
+                        iterables_repeat_wrap=False,
+                        closed_tags_for=["one"],
+                        data_sorter=data_sorter,
+                    )
+                    is serialized
+                )
 
-            FakeConverter.assert_called_once_with(1, 2, 3, a=5, b=8)
-            converter.build.assert_called_once_with(data)
+            FakeConverter.assert_called_once_with(wrap="wrap", indent="indent", newlines=False)
+            converter.build.assert_called_once_with(
+                data, iterables_repeat_wrap=False, closed_tags_for=["one"], data_sorter=data_sorter
+            )
 
     describe "Just Working":
 


### PR DESCRIPTION
Prior to this, arguments for build were passed into Converter instead of into build

Fixes #26